### PR TITLE
LINE Notify Appender 개발 #7

### DIFF
--- a/http/line_noti.http
+++ b/http/line_noti.http
@@ -1,0 +1,6 @@
+### https://engineering.linecorp.com/ko/blog/using-line-notify-to-send-messages-to-line-from-the-command-line/
+POST https://notify-api.line.me/api/notify
+Authorization: Bearer 토큰
+Content-Type: application/x-www-form-urlencoded
+
+message=테스트입니다.

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>

--- a/src/main/java/com/asdflog/blog/common/appender/LineNotifyAppender.java
+++ b/src/main/java/com/asdflog/blog/common/appender/LineNotifyAppender.java
@@ -1,0 +1,75 @@
+package com.asdflog.blog.common.appender;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+public class LineNotifyAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+      .ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+  private static final int LINE_NOTIFY_MESSAGE_MAX = 1000;
+
+  private final boolean nonUse;
+  private WebClient webClient;
+
+
+  public LineNotifyAppender() {
+
+    String lineNotifyToken = System.getProperty("asdflog.line.notify.token");
+
+    nonUse = StringUtils.isBlank(lineNotifyToken);
+    if (nonUse) {
+      return;
+    }
+
+    this.webClient = WebClient.builder()
+        .baseUrl("https://notify-api.line.me")
+        .defaultHeader(HttpHeaders.AUTHORIZATION,
+            "Bearer " + lineNotifyToken)
+        .build();
+  }
+
+  @Override
+  protected void append(ILoggingEvent iLoggingEvent) {
+    if (nonUse) {
+      return;
+    }
+
+    var fullMessage = iLoggingEventToString(iLoggingEvent);
+    var message = StringUtils.left(fullMessage, LINE_NOTIFY_MESSAGE_MAX);
+
+    try {
+      //"https://notify-api.line.me/api/notify"
+      webClient.post()
+          .uri("/api/notify")
+          .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+          .body(BodyInserters.fromFormData("message", message))
+          .retrieve().bodyToMono(String.class).timeout(Duration.ofSeconds(3)).block();
+    } catch (Exception exception) {
+      System.out.println("line notify error : " + exception.getMessage());
+    }
+  }
+
+  private static String iLoggingEventToString(ILoggingEvent iLoggingEvent) {
+    var time = LocalDateTime.ofInstant(Instant.ofEpochMilli(iLoggingEvent.getTimeStamp()),
+        TimeZone.getDefault().toZoneId()).format(DATE_TIME_FORMATTER);
+    var message = iLoggingEvent.getMessage();
+    var exception = ThrowableProxyUtil.asString(iLoggingEvent.getThrowableProxy());
+
+    return "time:" + time + "\n" +
+        "message:" + message + "\n" +
+        "exception:" + exception;
+  }
+
+}

--- a/src/main/java/com/asdflog/blog/common/appender/LineNotifyAppender.java
+++ b/src/main/java/com/asdflog/blog/common/appender/LineNotifyAppender.java
@@ -16,21 +16,22 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 public class LineNotifyAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
+  private static final String SYSTEM_PROPERTY_LINE_NOTIFY_TOKEN = "asdflog.line.notify.token";
   private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
       .ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
   private static final int LINE_NOTIFY_MESSAGE_MAX = 1000;
 
-  private final boolean nonUse;
-  private WebClient webClient;
+  private final WebClient webClient;
 
 
   public LineNotifyAppender() {
 
-    String lineNotifyToken = System.getProperty("asdflog.line.notify.token");
-
-    nonUse = StringUtils.isBlank(lineNotifyToken);
-    if (nonUse) {
-      return;
+    String lineNotifyToken = System.getProperty(SYSTEM_PROPERTY_LINE_NOTIFY_TOKEN);
+    if (StringUtils.isBlank(lineNotifyToken)) {
+      throw new IllegalStateException(
+          "In 'alpha','real' profile, VM option '-D" + SYSTEM_PROPERTY_LINE_NOTIFY_TOKEN
+              + "' is required. " + SYSTEM_PROPERTY_LINE_NOTIFY_TOKEN + " is " + lineNotifyToken
+              + ".");
     }
 
     this.webClient = WebClient.builder()
@@ -42,10 +43,6 @@ public class LineNotifyAppender extends UnsynchronizedAppenderBase<ILoggingEvent
 
   @Override
   protected void append(ILoggingEvent iLoggingEvent) {
-    if (nonUse) {
-      return;
-    }
-
     var fullMessage = iLoggingEventToString(iLoggingEvent);
     var message = StringUtils.left(fullMessage, LINE_NOTIFY_MESSAGE_MAX);
 

--- a/src/main/java/com/asdflog/blog/config/router/MonitorRouterConfig.java
+++ b/src/main/java/com/asdflog/blog/config/router/MonitorRouterConfig.java
@@ -8,28 +8,28 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
-import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Mono;
 
 @Configuration
 public class MonitorRouterConfig {
 
+  private static final String OK = "OK";
+
   @Bean
   public RouterFunction<ServerResponse> monitorRouter() {
     return RouterFunctions
-        .route(RequestPredicates.GET("/monitor/l7check"), MonitorHandler::ok);
+        .route(RequestPredicates.GET("/monitor/l7check"), serverRequest ->
+            ServerResponse.ok().contentType(MediaType.TEXT_PLAIN)
+                .cacheControl(CacheControl.noStore())
+                .body(BodyInserters.fromValue(OK)));
   }
 
-  static class MonitorHandler {
-
-    private static final String OK = "OK";
-
-    public static Mono<ServerResponse> ok(final ServerRequest request) {
-      return ServerResponse.ok().contentType(MediaType.TEXT_PLAIN)
-          .cacheControl(CacheControl.noStore())
-          .body(BodyInserters.fromValue(OK));
-    }
+  @Bean
+  public RouterFunction<ServerResponse> errorRouter() {
+    return RouterFunctions
+        .route(RequestPredicates.GET("/monitor/error"), serverRequest -> {
+          throw new RuntimeException("force error");
+        });
   }
 
 }

--- a/src/main/resources/config/logback-spring.xml
+++ b/src/main/resources/config/logback-spring.xml
@@ -30,17 +30,35 @@
         <pattern>${FILE_LOG_PATTERN}</pattern>
       </encoder>
     </appender>
+
+    <appender name="lineNotifyAppender" class="com.asdflog.blog.common.appender.LineNotifyAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+    </appender>
+
+    <appender name="lineNotifyAppenderAsyncAppender" class="ch.qos.logback.classic.AsyncAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+      <param name="neverBlock" value="true"/>
+      <param name="includeCallerData" value="true"/>
+      <param name="queueSize" value="2048"/>
+      <appender-ref ref="lineNotifyAppender"/>
+    </appender>
   </springProfile>
 
   <springProfile name="alpha">
     <root level="INFO">
       <appender-ref ref="dailyRollingFileAppender"/>
+      <appender-ref ref="lineNotifyAppenderAsyncAppender"/>
     </root>
   </springProfile>
 
   <springProfile name="real">
     <root level="INFO">
       <appender-ref ref="dailyRollingFileAppender"/>
+      <appender-ref ref="lineNotifyAppenderAsyncAppender"/>
     </root>
   </springProfile>
 </configuration>


### PR DESCRIPTION
- commons-lang3 추가
- line notify 테스트용 .http파일추가
- l7check를 람다를 사용해 표현하도록 수정
- error를 강제로 발생시키는 라우터 추가(에러전달 테스트용도)
- LineNotifyAppender 추가
- alpha,real에서 line notify를 이용해 오류를 전달할 수 있게 appender 설정 추가